### PR TITLE
Node.js version bump from 8 to the latest LTS release 14

### DIFF
--- a/RoomieReloaded/Dockerfile
+++ b/RoomieReloaded/Dockerfile
@@ -3,11 +3,12 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.2 as builder
 WORKDIR /etc/apt/apt.conf.d
 COPY ./RoomieReloaded/docker-build-image-apt-get-fix ./99fixbadproxy
 
-RUN apt-get update
-RUN apt-get install -y apt-transport-https lsb-release
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get install -y nodejs
-
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    lsb-release \
+    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 FROM builder as build
 WORKDIR /app


### PR DESCRIPTION
- Node.js 8 has reached end-of-life last year on 2019-12-31
- Node.js 14 is the latest LTS release and will be supported until April 2023

See: https://github.com/nodejs/Release